### PR TITLE
Fixed emitter bug, navigation and arrow slot bugs and set default rtl to false

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -4,9 +4,9 @@ import emitter from 'tiny-emitter/instance';
 import { h, ref } from 'vue'
 let EMITTER = {
   $on: (...args) => emitter.on(...args),
-  $once: (...args) => emitter.on(...args),
-  $off: (...args) => emitter.on(...args),
-  $emit: (...args) => emitter.on(...args)
+  $once: (...args) => emitter.once(...args),
+  $off: (...args) => emitter.off(...args),
+  $emit: (...args) => emitter.emit(...args)
 };
 
 export default {
@@ -480,7 +480,6 @@ export default {
       }
     },
     addGroupListeners() {
-      console.log('addGroupListeners', this.group, EMITTER)
       if (!this.group) {
         return;
       }

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -49,7 +49,7 @@ export default {
     },
     // enable rtl mode
     rtl: {
-      default: true,
+      default: false,
       type: Boolean
     },
     // enable auto sliding to carousel
@@ -480,6 +480,7 @@ export default {
       }
     },
     addGroupListeners() {
+      console.log('addGroupListeners', this.group, EMITTER)
       if (!this.group) {
         return;
       }

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -635,7 +635,8 @@ function renderSlides() {
  */
 function renderBody() {
   const slides = renderSlides.call(this, h);
-  const addons = this.$slots['hooper-addons'] || [];
+  const addonsFn = this.$slots['hooper-addons'];
+  const addons = Boolean(addonsFn) ? addonsFn() : [];
   const a11y = h(
     'div',
     {

--- a/src/Slide.js
+++ b/src/Slide.js
@@ -58,8 +58,6 @@ export default {
       'is-current': this.isCurrent
     };
 
-    const children = normalizeChildren(this);
-
     return h(
       'li',
       {
@@ -67,7 +65,7 @@ export default {
         style: this.style,
         '.aria-hidden': !this.isActive
       },
-      children
+      this.$slots.default()
     );
   }
 };

--- a/src/addons/Navigation.js
+++ b/src/addons/Navigation.js
@@ -11,8 +11,8 @@ function iconName(isVertical, isRTL, isPrev) {
 
 function renderButton(disabled, slot, isPrev, { isVertical, isRTL }, onClick) {
   const children =
-    slot && slot.length
-      ? slot
+    Boolean(slot)
+      ? slot()
       : [
           h(Icon, {
             props: {


### PR DESCRIPTION
- Fixed emitter bug-
- Fixed navigation and arrow slot bugs 
- Set default rtl to false to align with the original project's specification
- Removed wrapper requirement around slide contents to align with original specification

For those who want to install the fixes while being aware of the risks, you can install directly from github.

```bash
npm install -D github:phonezawphyo/hooper-vue3#42dfc0b
```